### PR TITLE
Update example.env

### DIFF
--- a/example.env
+++ b/example.env
@@ -1,7 +1,7 @@
 PERSIST_DIRECTORY=db
 LLM = path\to\model\name_of_model.bin
 BACKEND = gptj
-EMBEDDINGs_MODEL = all-MiniLM-L6-v2
+EMBEDDINGS_MODEL = all-MiniLM-L6-v2
 MODEL_N_CTX = 1000
 TARGET_SOURCE_CHUNKS = 6
 IGNORE_FOLDERS = '["folder\\\\to\\\\ignore", "folder\\\\to\\\\ignore2"]'


### PR DESCRIPTION
update example.env renaming EMBEDDINGs_MODEL to EMBEDDINGS_MODEL to fix bug that happens when copying the example configuration, which leads to the script not starting because HuggingFaceEmbeddings(model_name=self.emb_model) expects self.emb_model which is defined as EMBEDDINGS_MODEL (all capital letters)